### PR TITLE
Fix crash due to unclosed logs file

### DIFF
--- a/recovery/common/log.c
+++ b/recovery/common/log.c
@@ -25,5 +25,6 @@ void redirect_logs_to_file(const char *name) {
 void flush_logs() {
     if (log_file_handle != NULL) {
         fclose(log_file_handle);
+        log_file_handle = NULL;
     }
 }

--- a/recovery/convert_fs.c
+++ b/recovery/convert_fs.c
@@ -125,6 +125,9 @@ static enum convert_fs_state_e convert_fs(const struct convert_fs_config_s *conf
 
         debug_log("Detected FAT OS partition, starting conversion");
 
+        /* Flush logs and close log file before unmounting */
+        flush_logs();
+
         /* Unmount partitions*/
         debug_log("Unmounting partitions");
         err = vfs_unmount_deinit();


### PR DESCRIPTION
Fix crash that was happening because of
logs file left open before before partition
unmounting, what resulted in accessing
invalid handle and dereferencing null
pointer.