### PR TITLE
Fix Release and RelWithDebInfo target compilation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,50 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch BellHybrid PureRecovery (RelWithDebInfo RT1051)",
+            "type": "cortex-debug",
+            "request": "launch",
+            "executable": "${workspaceFolder}/build-BellHybrid-rt1051-RelWithDebInfo/PureRecovery.elf",
+            "servertype": "jlink",
+            "serverpath": "JLinkGDBServerCLExe",
+            "cwd": "${workspaceFolder}",
+            "gdbPath": "arm-none-eabi-gdb",
+            "serverArgs": ["-strict", "-ir", "-speed", "25000"],
+            "interface": "swd",
+            "device": "MCIMXRT1051",
+            "jlinkscript": "${workspaceFolder}/evkbimxrt1050_sdram_init_T6.jlinkscript",
+            "overrideLaunchCommands": [
+                "monitor reset 0",
+                "monitor halt",
+                "monitor memU32 0x401BC000 = 128;",
+                "load",
+                "b main",
+                "b ResetISR",
+            ]
+        },
+        {
+            "name": "Launch PurePhone PureRecovery (RelWithDebInfo RT1051)",
+            "type": "cortex-debug",
+            "request": "launch",
+            "executable": "${workspaceFolder}/build-PurePhone-rt1051-RelWithDebInfo/PureRecovery.elf",
+            "servertype": "jlink",
+            "serverpath": "JLinkGDBServerCLExe",
+            "cwd": "${workspaceFolder}",
+            "gdbPath": "arm-none-eabi-gdb",
+            "serverArgs": ["-strict", "-ir", "-speed", "25000"],
+            "interface": "swd",
+            "device": "MCIMXRT1051",
+            "jlinkscript": "${workspaceFolder}/evkbimxrt1050_sdram_init.jlinkscript",
+            "overrideLaunchCommands": [
+                "monitor reset 0",
+                "monitor halt",
+                "monitor memU32 0x401BC000 = 128;",
+                "load",
+                "b main",
+                "b ResetISR",
+            ]
+        }
+    ]
+}
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,177 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+        // Configure BellBellHybrid
+        {
+            "type": "shell",
+            "label": "Configure BellHybrid (Release RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "bell",
+                "rt1051",
+                "Release"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Configure BellHybrid (RelWithDebInfo RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "bell",
+                "rt1051",
+                "RelWithDebInfo"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Configure BellHybrid (Debug RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "bell",
+                "rt1051",
+                "Debug"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        // Build BellBellHybrid
+        {
+            "type": "shell",
+            "label": "Build BellHybrid (Release RT1051)",
+            "command": "make",
+            "args": [
+                "-j`nproc`"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-rt1051-Release"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake",
+        },
+        {
+            "type": "shell",
+            "label": "Build BellHybrid (RelWithDebInfo RT1051)",
+            "command": "make",
+            "args": [
+                "-j`nproc`"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-rt1051-RelWithDebInfo"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake",
+        },
+		{
+            "type": "shell",
+            "label": "Build BellHybrid (Debug RT1051)",
+            "command": "make",
+            "args": [
+                "-j`nproc`"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-BellHybrid-rt1051-Debug"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake",
+        },
+        // Configure PurePhone
+        {
+            "type": "shell",
+            "label": "Configure PurePhone (Release RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "pure",
+                "rt1051",
+                "Release"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Configure PurePhone (RelWithDebInfo RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "pure",
+                "rt1051",
+                "RelWithDebInfo"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        {
+            "type": "shell",
+            "label": "Configure PurePhone (Debug RT1051)",
+            "command": "./configure.sh",
+            "args": [
+                "pure",
+                "rt1051",
+                "Debug"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "detail": "Run cmake configure script",
+        },
+        // Build PurePhone
+        {
+            "type": "shell",
+            "label": "Build PurePhone (Release RT1051)",
+            "command": "make",
+            "args": [
+                "-j`nproc`"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-PurePhone-rt1051-Release"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake",
+        },
+        {
+            "type": "shell",
+            "label": "Build PurePhone (RelWithDebInfo RT1051)",
+            "command": "make",
+            "args": [
+                "-j`nproc`"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-PurePhone-rt1051-RelWithDebInfo"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake",
+        },
+        {
+            "type": "shell",
+            "label": "Build PurePhone (Debug RT1051)",
+            "command": "make",
+            "args": [
+                "-j`nproc`"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/build-PurePhone-rt1051-Debug"
+            },
+            "group": "build",
+            "detail": "Build dir has to be configured with Cmake",
+        }
+	]
+}

--- a/cmake/modules/toolchain-arm-none-eabi.cmake
+++ b/cmake/modules/toolchain-arm-none-eabi.cmake
@@ -55,16 +55,16 @@ set(CMAKE_ASM_FLAGS_DEBUG "-g -DDEBUG" CACHE INTERNAL "ASM Compiler options for 
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "" CACHE INTERNAL "Linker options for debug build type")
 
 # Options for RELEASE build
-set(CMAKE_C_FLAGS_RELEASE "-O2 -flto" CACHE INTERNAL "C Compiler options for release build type")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -flto" CACHE INTERNAL "C++ Compiler options for release build type")
+set(CMAKE_C_FLAGS_RELEASE "-O2" CACHE INTERNAL "C Compiler options for release build type")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2" CACHE INTERNAL "C++ Compiler options for release build type")
 set(CMAKE_ASM_FLAGS_RELEASE "" CACHE INTERNAL "ASM Compiler options for release build type")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-O2 -flto" CACHE INTERNAL "Linker options for release build type")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-O2" CACHE INTERNAL "Linker options for release build type")
 
 # Flags for RELWITHDEBINFO build
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -flto -g" CACHE INTERNAL "C Compiler options for relwithdebinfo build type")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -flto -g" CACHE INTERNAL "C++ Compiler options for relwithdebinfo build type")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g" CACHE INTERNAL "C Compiler options for relwithdebinfo build type")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g" CACHE INTERNAL "C++ Compiler options for relwithdebinfo build type")
 set(CMAKE_ASM_FLAGS_RELWITHDEBINFO "" CACHE INTERNAL "ASM Compiler options for relwithdebinfo build type")
-set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "-O2 -flto" CACHE INTERNAL "Linker options for relwithdebinfo build type")
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "-O2" CACHE INTERNAL "Linker options for relwithdebinfo build type")
 
 
 #############################


### PR DESCRIPTION
This commit removes -flto flag which interferes with build targets. Added build and debug scripts for vsc.