### PR TITLE
[BH-1770] Init SPI by default config

### DIFF
--- a/hal/src/display/ED028TC1.c
+++ b/hal/src/display/ED028TC1.c
@@ -97,6 +97,8 @@ EinkStatus_e EinkInitialize()
     gpio_pin_config_t gpio_config = {kGPIO_DigitalOutput, 0, kGPIO_NoIntmode};
     lpspi_master_config_t masterConfig;
 
+    LPSPI_MasterGetDefaultConfig(&masterConfig);
+
     /* Master config */
     masterConfig.baudRate = TRANSFER_BAUDRATE;
     masterConfig.bitsPerFrame = 8;


### PR DESCRIPTION
The new fsl needs to get default config
before changing SPI modes, speeds etc.